### PR TITLE
Update copy-webpack-plugin from 5.0.4 to 6.0.3

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -17,13 +17,17 @@ module.exports.webpack = {
         new MiniCssExtractPlugin({
           filename: 'index.bundle.css'
         }),
-        new CopyPlugin([
-          {
-            from: './assets',
-            to: '../',
-            ignore: ['js/**/*', 'styles/**/*', '.eslintrc']
-          },
-        ]),
+        new CopyPlugin({
+          patterns: [
+            {
+              from: './assets',
+              to: '../',
+              globOptions: {
+                ignore: ['js/**/*', 'styles/**/*', '.eslintrc']
+              },
+            },
+          ],
+        }),
       ],
       module: {
         rules: [

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "babel-loader": "^8.0.6",
-    "copy-webpack-plugin": "^5.0.4",
+    "copy-webpack-plugin": "^6.0.3",
     "css-loader": "^3.2.0",
     "eslint": "5.16.0",
     "htmlhint": "0.11.0",


### PR DESCRIPTION
Changed the `config/webpack.js` according to the [Changelog of copy-webpack-plugin v6.0.0](https://github.com/webpack-contrib/copy-webpack-plugin/releases/tag/v6.0.0):
> the plugin now accepts an object, you should change `new CopyPlugin(patterns, options)` to `new CopyPlugin({ patterns, options })`
> the `ignore` option was removed in favor `globOptions.ignore`

